### PR TITLE
Remove Node 20 TODO notes

### DIFF
--- a/codex-cli/src/components/chat/terminal-chat-command-review.tsx
+++ b/codex-cli/src/components/chat/terminal-chat-command-review.tsx
@@ -1,6 +1,6 @@
 import { ReviewDecision } from "../../utils/agent/review";
-// TODO: figure out why `cli-spinners` fails on Node v20.9.0
-// which is why we have to do this in the first place
+// `cli-spinners` had issues with Node 20.9.0. We require Node 22 now, so
+// this vendor import is kept only for historical reasons.
 //
 // @ts-expect-error select.js is JavaScript and has no types
 import { Select } from "../vendor/ink-select/select";

--- a/codex-cli/src/components/onboarding/onboarding-approval-mode.tsx
+++ b/codex-cli/src/components/onboarding/onboarding-approval-mode.tsx
@@ -4,8 +4,8 @@ import { Box, Text } from "ink";
 import React from "react";
 import { AutoApprovalMode } from "src/utils/auto-approval-mode";
 
-// TODO: figure out why `cli-spinners` fails on Node v20.9.0
-// which is why we have to do this in the first place
+// `cli-spinners` had issues with Node 20.9.0, but we now require Node 22 so
+// this workaround remains only for historical reasons.
 
 export function OnboardingApprovalMode(): React.ReactElement {
   return (


### PR DESCRIPTION
## Summary
- clean up TODO comments about Node 20.9.0
- note that cli-spinners works since Node 22 is required

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_683f823a37e483249255673453fc7c5b